### PR TITLE
fix: run tests before publishing in generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Run tests
+        run: npm test
+
       - name: Check for changes
         id: changes
         run: |


### PR DESCRIPTION
## Summary
- The generate workflow generates endpoint tests (`generate-endpoint-tests.ts`) but never actually runs them before publishing to npm
- This means a broken regeneration (model rename, missing export, etc.) ships without any validation, same class of bug as getlate-dev/late-python#12
- Adds `npm test` step between typecheck and publish

## Test plan
- [ ] Trigger Regenerate workflow manually and verify tests run
- [ ] If tests fail, publish is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)