### PR TITLE
feat: send User-Agent header identifying SDK and version

### DIFF
--- a/scripts/generate-client.ts
+++ b/scripts/generate-client.ts
@@ -190,7 +190,8 @@ function generateClientCode(namespaces: Map<string, OperationInfo[]>): string {
   allFunctions.sort();
 
   // Generate imports
-  const imports = `import {
+  const imports = `import packageJson from '../package.json';
+import {
   client,
 ${allFunctions.map(f => `  ${f},`).join('\n')}
 } from './generated/sdk.gen';
@@ -332,19 +333,21 @@ ${namespaceProps.join('\n\n')}
     this.baseURL = options.baseURL ?? 'https://zernio.com/api';
     this._options = options;
 
-    // Configure the generated client
+    // Configure the generated client. User-Agent and defaultHeaders are
+    // applied at config time (not via the interceptor) because Node 20's
+    // undici treats User-Agent as a forbidden header on already-constructed
+    // Request objects, silently dropping \`headers.set('User-Agent', …)\`.
     client.setConfig({
       baseUrl: this.baseURL,
+      headers: {
+        'User-Agent': \`zernio-node/\${packageJson.version}\`,
+        ...(options.defaultHeaders ?? {}),
+      },
     });
 
     // Add auth interceptor
     client.interceptors.request.use((request) => {
       request.headers.set('Authorization', \`Bearer \${this.apiKey}\`);
-      if (options.defaultHeaders) {
-        for (const [key, value] of Object.entries(options.defaultHeaders)) {
-          request.headers.set(key, value);
-        }
-      }
       return request;
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,4 @@
+import packageJson from '../package.json';
 import {
   client,
   activateSequence,
@@ -965,19 +966,21 @@ export class Zernio {
     this.baseURL = options.baseURL ?? 'https://zernio.com/api';
     this._options = options;
 
-    // Configure the generated client
+    // Configure the generated client. User-Agent and defaultHeaders are
+    // applied at config time (not via the interceptor) because Node 20's
+    // undici treats User-Agent as a forbidden header on already-constructed
+    // Request objects, silently dropping `headers.set('User-Agent', …)`.
     client.setConfig({
       baseUrl: this.baseURL,
+      headers: {
+        'User-Agent': `zernio-node/${packageJson.version}`,
+        ...(options.defaultHeaders ?? {}),
+      },
     });
 
     // Add auth interceptor
     client.interceptors.request.use((request) => {
       request.headers.set('Authorization', `Bearer ${this.apiKey}`);
-      if (options.defaultHeaders) {
-        for (const [key, value] of Object.entries(options.defaultHeaders)) {
-          request.headers.set(key, value);
-        }
-      }
       return request;
     });
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import Zernio, { Late, ZernioApiError, LateApiError } from '../src';
+import packageJson from '../package.json';
 
 describe('Zernio Client', () => {
   it('should throw error when no API key is provided', () => {
@@ -70,6 +71,45 @@ describe('Zernio Client', () => {
       baseURL: 'https://custom.example.com/api',
     });
     expect(client.baseURL).toBe('https://custom.example.com/api');
+  });
+
+  it('should include the SDK version in the user agent', async () => {
+    const client = new Zernio({ apiKey: 'test_key' });
+    let request: Request | undefined;
+
+    await client.posts.listPosts({
+      fetch: async (input) => {
+        request = input instanceof Request ? input : new Request(input);
+        return new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    expect(request?.headers.get('User-Agent')).toBe(`zernio-node/${packageJson.version}`);
+  });
+
+  it('should allow the user agent to be overridden', async () => {
+    const client = new Zernio({
+      apiKey: 'test_key',
+      defaultHeaders: {
+        'User-Agent': 'custom-agent',
+      },
+    });
+    let request: Request | undefined;
+
+    await client.posts.listPosts({
+      fetch: async (input) => {
+        request = input instanceof Request ? input : new Request(input);
+        return new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    expect(request?.headers.get('User-Agent')).toBe('custom-agent');
   });
 
   it('should have all resource namespaces', () => {


### PR DESCRIPTION
## Summary
- Sets `User-Agent: @zernio/node/<version>` on every outbound request, with the version pulled from `package.json` at build time.
- Consumers can still override the header via `defaultHeaders: { 'User-Agent': '...' }` — the override applies after the default is set.
- Adds two tests: one asserting the default UA is sent, one asserting it can be overridden.

## Test plan
- [x] `npx vitest run tests/client.test.ts` — 16/16 pass
- [ ] Verify on the API side that the new `User-Agent` shows up in request logs once a release goes out