### PR TITLE
fix: stop leaking the client selector into RequestInit (breaks Deno / edge runtimes)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1835,6 +1835,32 @@ export class Zernio {
       })
     );
 
+    // `_bind` injects this instance's client under the `client` key so each
+    // operation runs on the right per-instance client. @hey-api/client-fetch
+    // then spreads the whole per-request options object — `client` included —
+    // into the fetch `RequestInit`. Node's undici ignores unknown init fields,
+    // but Deno (and other WinterCG runtimes) reject a `client` that is not a
+    // `Deno.HttpClient`, so `new Request(...)` throws
+    // "Failed to construct 'Request': Argument 2 `client` must be a
+    // Deno.HttpClient" and every call fails under Deno Deploy, Supabase Edge
+    // Functions, Cloudflare Workers, etc. The selector has already done its job
+    // before the HTTP method runs, so strip it before the request is built.
+    const dispatchers = this._client as unknown as Record<
+      string,
+      (requestOptions?: Record<string, unknown>) => unknown
+    >;
+    for (const method of ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace', 'connect']) {
+      const dispatch = dispatchers[method].bind(this._client);
+      dispatchers[method] = (requestOptions) => {
+        if (requestOptions && 'client' in requestOptions) {
+          const withoutClientSelector = { ...requestOptions };
+          delete withoutClientSelector['client'];
+          return dispatch(withoutClientSelector);
+        }
+        return dispatch(requestOptions);
+      };
+    }
+
     // Add auth interceptor
     this._client.interceptors.request.use((request) => {
       request.headers.set('Authorization', `Bearer ${this.apiKey}`);

--- a/tests/request-init.test.ts
+++ b/tests/request-init.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Zernio from '../src';
+
+/**
+ * `_bind` injects this instance's client under the `client` key so each call
+ * runs on the right per-instance client. @hey-api/client-fetch then spreads the
+ * whole per-request options object into the fetch `RequestInit`. Node's undici
+ * ignores unknown init fields, but Deno (and other WinterCG runtimes) reject a
+ * `client` that is not a `Deno.HttpClient` — `new Request(...)` throws and every
+ * call fails under Deno Deploy, Supabase Edge Functions, Cloudflare Workers.
+ *
+ * This asserts the selector never reaches the RequestInit. It runs under Node,
+ * so it captures the init at `new Request` time (undici would otherwise silently
+ * swallow the stray field and hide the bug).
+ */
+describe('request construction (Deno / WinterCG compatibility)', () => {
+  const OriginalRequest = globalThis.Request;
+  const originalFetch = globalThis.fetch;
+  let capturedInits: (RequestInit | undefined)[];
+
+  beforeEach(() => {
+    capturedInits = [];
+    globalThis.Request = class extends OriginalRequest {
+      constructor(input: RequestInfo | URL, init?: RequestInit) {
+        capturedInits.push(init);
+        super(input, init);
+      }
+    } as unknown as typeof Request;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.Request = OriginalRequest;
+    globalThis.fetch = originalFetch;
+  });
+
+  it('never leaks the internal client into the fetch RequestInit', async () => {
+    const client = new Zernio({ apiKey: 'sk_test' });
+
+    await client.accounts.listAccounts({});
+
+    expect(capturedInits.length).toBeGreaterThan(0);
+    for (const init of capturedInits) {
+      expect(init && 'client' in init).toBe(false);
+    }
+  });
+
+  it('still selects the per-instance client (auth header is applied)', async () => {
+    const authHeaders: (string | null)[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      authHeaders.push((input as Request).headers.get('Authorization'));
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const client = new Zernio({ apiKey: 'sk_ABCD' });
+    await client.accounts.listAccounts({});
+
+    expect(authHeaders).toEqual(['Bearer sk_ABCD']);
+  });
+});


### PR DESCRIPTION
## Summary

Every SDK call throws under **Deno** and other WinterCG runtimes (Supabase Edge Functions, Deno Deploy, Cloudflare Workers):

```
TypeError: Failed to construct 'Request': Argument 2 `client` must be a Deno.HttpClient
```

It fails **before any network I/O**, so it looks like a total outage of the SDK on those runtimes. It works on Node, which is why the current test suite doesn't catch it.

## Root cause

`_bind` (src/client.ts) injects this instance's client under the `client` key so each operation runs on the right per-instance client:

```ts
const withClient = { ...options };
if (withClient['client'] === undefined) {
  withClient['client'] = this._client;
}
return operation(withClient);
```

The generated operation then does `(options?.client ?? client).get({ ...options, url })`, and `@hey-api/client-fetch@0.6` spreads that whole options object — `client` included — straight into the fetch `RequestInit` (`new Request(url, { ...init, client })`).

- **Node (undici):** silently ignores unknown `RequestInit` fields → the stray `client` is harmless → tests stay green.
- **Deno / WinterCG:** `new Request` validates `client` as a `Deno.HttpClient` and rejects the hey-api client object → every call throws.

This matters because the SDK's own docs target edge runtimes, and it's currently unusable there (confirmed on `0.2.315` → present through `0.2.540`).

## Fix

The `client` selector has already done its job (picking the per-instance client) by the time the HTTP method runs, so strip it from the options before hey-api builds the request. One localized change in the constructor; per-instance isolation (auth interceptor, `baseURL`, `defaultHeaders`) is unaffected.

## Tests

- Added `tests/request-init.test.ts` — asserts the `client` selector never reaches the `RequestInit`, captured at `new Request` time (undici would otherwise swallow it and hide the bug). **Fails on the previous behaviour, passes with this change.**
- Full suite green: `npm test` → **177 passed** (including the existing `isolation.test.ts`).
- Verified under the actual failing runtime: a Deno script calling `client.accounts.listAccounts()` against a stubbed `fetch` **throws before this change and succeeds after**.

## Notes for maintainers

- This is a minimal, dependency-free fix. Alternatives you might prefer: bumping `@hey-api/client-fetch` to a version that no longer spreads non-`RequestInit` keys, or having `_bind` avoid the `client` field entirely.
- The gap is environmental: the Node-only test matrix can't observe this. Consider adding a small **Deno** (or `workerd`) job that runs one real call against a stub `fetch` — it would guard this whole class of runtime breakage going forward. Happy to add that here if you'd like.